### PR TITLE
feat: added `all` option to traf/nx

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ npx @traf/nx@latest affected <action> [options]
 | -------------------- | ------------------------------------------------------------------------------------ | -------------------- |
 | `--cwd`              | The current working directory                                                        | `process.cwd()`      |
 | `--base`             | The base branch to compare against                                                   | `origin/main`        |
+| `--all`              | Outputs all available projects regardless of changes                                 | `false`              |
 | `--tsConfigFilePath` | The path to the root tsconfig file                                                   | `tsconfig.base.json` |
 | `--action`           | The action to perform. Can be any command                                            | `log`                |
 | `--json`             | Output the result as JSON                                                            | `false`              |

--- a/libs/nx/README.md
+++ b/libs/nx/README.md
@@ -19,6 +19,7 @@ npx @traf/nx@latest affected <action> [options]
 | Option               | Description                                                                          | Default              |
 | -------------------- | ------------------------------------------------------------------------------------ | -------------------- |
 | `--cwd`              | The current working directory                                                        | `process.cwd()`      |
+| `--all`              | Outputs all available projects regardless of changes                                 | `false`              |
 | `--base`             | The base branch to compare against                                                   | `origin/main`        |
 | `--tsConfigFilePath` | The path to the root tsconfig file                                                   | `tsconfig.base.json` |
 | `--action`           | The action to perform. Can be any command                                            | `log`                |

--- a/libs/nx/src/cli.spec.ts
+++ b/libs/nx/src/cli.spec.ts
@@ -51,6 +51,7 @@ describe('cli', () => {
       runCommand(['affected']);
       expect(affectedActionSpy).toBeCalledWith({
         action: 'log',
+        all: false,
         base: 'origin/main',
         cwd: process.cwd(),
         includeFiles: [],
@@ -64,6 +65,7 @@ describe('cli', () => {
       runCommand([
         'affected',
         'build',
+        '--all=true',
         '--base=master',
         '--tsConfigFilePath=tsconfig.json',
         `--cwd=${workspaceCwd}`,
@@ -71,6 +73,7 @@ describe('cli', () => {
       ]);
       expect(affectedActionSpy).toBeCalledWith({
         action: 'build',
+        all: 'true',
         base: 'master',
         cwd: resolve(process.cwd(), workspaceCwd),
         includeFiles: ['package.json', 'jest.setup.js'],
@@ -105,6 +108,7 @@ describe('cli', () => {
 
       await cli.affectedAction({
         action: 'log',
+        all: false,
         base: 'origin/main',
         cwd: process.cwd(),
         includeFiles: [],
@@ -129,6 +133,7 @@ describe('cli', () => {
 
       await cli.affectedAction({
         action: 'log',
+        all: false,
         base: 'origin/main',
         cwd: process.cwd(),
         includeFiles: [],
@@ -145,6 +150,7 @@ describe('cli', () => {
 
       await cli.affectedAction({
         action: 'log',
+        all: false,
         base: 'origin/main',
         cwd: process.cwd(),
         includeFiles: [],
@@ -164,6 +170,7 @@ describe('cli', () => {
 
       await cli.affectedAction({
         action: 'build',
+        all: false,
         base: 'origin/main',
         cwd: process.cwd(),
         includeFiles: [],
@@ -181,6 +188,47 @@ describe('cli', () => {
         expectedCommand,
         expect.anything()
       );
+    });
+
+    describe('`all` option', () => {
+      beforeEach(() => {
+        trafSpy.mockResolvedValueOnce(['proj1']);
+
+        getNxTrueAffectedProjectsSpy.mockResolvedValueOnce([
+          { name: 'proj1', sourceRoot: 'mock', tsConfig: 'mock' },
+          { name: 'proj2', sourceRoot: 'mock', tsConfig: 'mock' },
+        ]);
+      })
+
+      it('should return only affected projects when `all` is false', async () => {
+        await cli.affectedAction({
+          action: 'log',
+          all: false,
+          base: 'origin/main',
+          cwd: process.cwd(),
+          includeFiles: [],
+          json: false,
+          restArgs: [],
+          tsConfigFilePath: 'tsconfig.base.json',
+        });
+
+        expect(logSpy).toHaveBeenCalledWith('Affected projects:\n - proj1');
+      });
+
+      it('should return all projects regardless of changes when `all` is true', async () => {
+        await cli.affectedAction({
+          action: 'log',
+          all: true,
+          base: 'origin/main',
+          cwd: process.cwd(),
+          includeFiles: [],
+          json: false,
+          restArgs: [],
+          tsConfigFilePath: 'tsconfig.base.json',
+        });
+
+        expect(logSpy).toHaveBeenCalledWith('Affected projects:\n - proj1\n - proj2');
+      });
     });
   });
 });

--- a/libs/nx/src/cli.ts
+++ b/libs/nx/src/cli.ts
@@ -17,6 +17,7 @@ export const log = (message: string) =>
 export const affectedAction = async ({
   cwd,
   action = 'log',
+  all = false,
   base = 'origin/main',
   json,
   restArgs,
@@ -24,13 +25,16 @@ export const affectedAction = async ({
   includeFiles,
 }: AffectedOptions) => {
   const projects = await getNxTrueAffectedProjects(cwd);
-  const affected = await trueAffected({
-    cwd,
-    rootTsConfig: tsConfigFilePath,
-    base,
-    projects,
-    includeFiles,
-  });
+
+  const affected = all
+    ? projects.map((p) => p.name)
+    : await trueAffected({
+        cwd,
+        rootTsConfig: tsConfigFilePath,
+        base,
+        projects,
+        includeFiles,
+      });
 
   if (json) {
     console.log(JSON.stringify(affected));
@@ -70,6 +74,7 @@ interface AffectedOptions {
   cwd: string;
   tsConfigFilePath: string;
   action: string;
+  all: boolean;
   base: string;
   json: boolean;
   includeFiles: string[];
@@ -93,6 +98,10 @@ const affectedCommand: CommandModule<unknown, AffectedOptions> = {
       desc: 'Action to run on affected projects',
       default: 'log',
     },
+    all: {
+      desc: 'Outputs all available projects regardless of changes',
+      default: false,
+    },
     base: {
       desc: 'Base branch to compare against',
       default: 'origin/main',
@@ -113,6 +122,7 @@ const affectedCommand: CommandModule<unknown, AffectedOptions> = {
   handler: async ({
     cwd,
     tsConfigFilePath,
+    all,
     action,
     base,
     json,
@@ -126,6 +136,7 @@ const affectedCommand: CommandModule<unknown, AffectedOptions> = {
     await affectedAction({
       cwd,
       tsConfigFilePath,
+      all,
       action,
       base,
       json,


### PR DESCRIPTION
This adds the `--all=true` option to the `nx` library, in order to disregard affected projects and just emit all of them.

### use-case:

When wanting to trigger a complete build & publish process of all libraries (due to an infrastructure change for example), without having to manually modify all libraries.
