### PR TITLE
fix: make git diff relative to current working directory

### DIFF
--- a/libs/core/src/git.spec.ts
+++ b/libs/core/src/git.spec.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'fs/promises';
 import * as childProcess from 'node:child_process';
 
 const cwd = 'libs/core/src/__fixtures__/git';
+const absoluteCwd = resolve(cwd);
 const branch = 'main';
 
 describe('git', () => {
@@ -115,10 +116,24 @@ describe('git', () => {
   });
 
   describe('getChangedFiles', () => {
-    it('should return changed files with line numbers', () => {
+    it('should return changed files with line numbers from relative cwd path', () => {
       const changedFiles = getChangedFiles({
         base: branch,
         cwd,
+      });
+
+      expect(changedFiles).toEqual([
+        {
+          filePath: 'index.ts',
+          changedLines: [3],
+        },
+      ]);
+    });
+
+    it('should return changed files with line numbers from absolute cwd path', () => {
+      const changedFiles = getChangedFiles({
+        base: branch,
+        cwd: absoluteCwd,
       });
 
       expect(changedFiles).toEqual([

--- a/libs/core/src/git.ts
+++ b/libs/core/src/git.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
 
 const TEN_MEGABYTES = 1024 * 10000;
 
@@ -41,11 +42,15 @@ export function getMergeBase({
 
 export function getDiff({ base, cwd }: BaseGitActionArgs): string {
   try {
-    return execSync(`git diff ${base} --unified=0 --relative -- ${cwd}`, {
-      maxBuffer: TEN_MEGABYTES,
-      cwd,
-      stdio: 'pipe',
-    })
+    const resolvedPath = cwd ? resolve(cwd) : cwd;
+    return execSync(
+      `git diff ${base} --unified=0 --relative -- ${resolvedPath}`,
+      {
+        maxBuffer: TEN_MEGABYTES,
+        cwd,
+        stdio: 'pipe',
+      }
+    )
       .toString()
       .trim();
   } catch (e) {

--- a/libs/core/src/git.ts
+++ b/libs/core/src/git.ts
@@ -42,15 +42,15 @@ export function getMergeBase({
 
 export function getDiff({ base, cwd }: BaseGitActionArgs): string {
   try {
-    const resolvedPath = cwd ? resolve(cwd) : cwd;
-    return execSync(
-      `git diff ${base} --unified=0 --relative -- ${resolvedPath}`,
-      {
-        maxBuffer: TEN_MEGABYTES,
-        cwd,
-        stdio: 'pipe',
-      }
-    )
+    const diffCommand = cwd
+      ? `git diff ${base} --unified=0 --relative -- ${resolve(cwd)}`
+      : `git diff ${base} --unified=0 `;
+
+    return execSync(diffCommand, {
+      maxBuffer: TEN_MEGABYTES,
+      cwd,
+      stdio: 'pipe',
+    })
       .toString()
       .trim();
   } catch (e) {

--- a/libs/core/src/git.ts
+++ b/libs/core/src/git.ts
@@ -41,7 +41,7 @@ export function getMergeBase({
 
 export function getDiff({ base, cwd }: BaseGitActionArgs): string {
   try {
-    return execSync(`git diff ${base} --unified=0`, {
+    return execSync(`git diff ${base} --unified=0 --relative -- ${cwd}`, {
       maxBuffer: TEN_MEGABYTES,
       cwd,
       stdio: 'pipe',


### PR DESCRIPTION
I tried to use traf on one of my turbo monorepo, but it couldn't detect affected files :'-(

After investigating a bit the source code, I discovered the issue was due to my current working directory being a subfolder in the git hierarchy.

Here is a failing folder structure :
```
my-git-repo/
 ├──my-monorepo/ 
 │   │
 │   ├──apps/
 │   │   └──...
 │   │
 │   ├──packages/
 │   │   └──...
 │   │
 │   └──...
 │ 
 └──... 
```

If I modified for instance a file `my-git-repo/my-monorepo/packages/a/src/file.js` and then I execute `npx @traf/turbo@latest affected log` from `my-git-repo/my-monorepo`, it doesn't detect changed files because the `git diff` returns that `my-git-repo/my-monorepo/packages/a/src/file.js` has changed but traf is looking for a change in `my-monorepo/packages/a/src/file.js`.

To make it works, I modified the `git diff` command executed by traf to be relative to the current working directory. I used the [--relative option](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---relativeltpathgt) for that.