### PR TITLE
feat(nx): add the ability to filter truly affected by target(s)

### DIFF
--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -3,7 +3,7 @@ export interface TrueAffectedProject {
   sourceRoot: string;
   tsConfig?: string;
   implicitDependencies?: string[];
-  targets: string[];
+  targets?: string[];
 }
 
 export interface TrueAffected {

--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -3,6 +3,7 @@ export interface TrueAffectedProject {
   sourceRoot: string;
   tsConfig?: string;
   implicitDependencies?: string[];
+  targets: string[];
 }
 
 export interface TrueAffected {

--- a/libs/nx/README.md
+++ b/libs/nx/README.md
@@ -17,7 +17,7 @@ npx @traf/nx@latest affected <action> [options]
 ### **Options**
 
 | Option               | Description                                                                          | Default              |
-| -------------------- | ------------------------------------------------------------------------------------ | -------------------- |
+|----------------------|--------------------------------------------------------------------------------------| -------------------- |
 | `--cwd`              | The current working directory                                                        | `process.cwd()`      |
 | `--all`              | Outputs all available projects regardless of changes                                 | `false`              |
 | `--base`             | The base branch to compare against                                                   | `origin/main`        |
@@ -25,3 +25,4 @@ npx @traf/nx@latest affected <action> [options]
 | `--action`           | The action to perform. Can be any command                                            | `log`                |
 | `--json`             | Output the result as JSON                                                            | `false`              |
 | `--includeFiles`     | Comma separated list of glob patterns to include (relative to projects' source root) |                      |
+| `--target`           | Comma separated list of targets to filter affected projects by                       |                      |

--- a/libs/nx/src/cli.spec.ts
+++ b/libs/nx/src/cli.spec.ts
@@ -125,6 +125,7 @@ describe('cli', () => {
         json: false,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.base.json',
+        target: [],
       });
 
       expect(getNxTrueAffectedProjectsSpy).toBeCalledWith(process.cwd());
@@ -150,6 +151,7 @@ describe('cli', () => {
         json: false,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.base.json',
+        target: [],
       });
 
       expect(logSpy).toHaveBeenCalledWith('No affected projects');
@@ -167,6 +169,7 @@ describe('cli', () => {
         json: false,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.base.json',
+        target: [],
       });
 
       expect(logSpy).toHaveBeenCalledWith('Affected projects:\n - proj1');
@@ -186,6 +189,7 @@ describe('cli', () => {
         json: true,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.base.json',
+        target: [],
       });
 
       expect(consoleSpy).toHaveBeenCalledWith('["proj1"]');
@@ -206,6 +210,7 @@ describe('cli', () => {
         json: false,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.base.json',
+        target: [],
       });
 
       const expectedCommand = `npx nx run-many --target=build --projects=proj1 `;
@@ -219,13 +224,50 @@ describe('cli', () => {
       );
     });
 
+    describe('`target` option', () => {
+      beforeEach(() => {
+        trafSpy.mockResolvedValueOnce(['proj1']);
+
+        getNxTrueAffectedProjectsSpy.mockResolvedValueOnce([
+          {
+            name: 'proj1',
+            sourceRoot: 'mock',
+            tsConfig: 'mock',
+            targets: ['build'],
+          },
+          {
+            name: 'proj2',
+            sourceRoot: 'mock',
+            tsConfig: 'mock',
+            targets: ['test'],
+          },
+        ]);
+      });
+
+      it('should only return projects with a build target', async () => {
+        await cli.affectedAction({
+          action: 'log',
+          all: false,
+          base: 'origin/main',
+          cwd: process.cwd(),
+          includeFiles: [],
+          json: false,
+          restArgs: [],
+          tsConfigFilePath: 'tsconfig.base.json',
+          target: ['build'],
+        });
+
+        expect(logSpy).toHaveBeenCalledWith('Affected projects:\n - proj1');
+      });
+    });
+
     describe('`all` option', () => {
       beforeEach(() => {
         trafSpy.mockResolvedValueOnce(['proj1']);
 
         getNxTrueAffectedProjectsSpy.mockResolvedValueOnce([
-          { name: 'proj1', sourceRoot: 'mock', tsConfig: 'mock' },
-          { name: 'proj2', sourceRoot: 'mock', tsConfig: 'mock' },
+          { name: 'proj1', sourceRoot: 'mock', tsConfig: 'mock', targets: [] },
+          { name: 'proj2', sourceRoot: 'mock', tsConfig: 'mock', targets: [] },
         ]);
       });
 
@@ -239,6 +281,7 @@ describe('cli', () => {
           json: false,
           restArgs: [],
           tsConfigFilePath: 'tsconfig.base.json',
+          target: [],
         });
 
         expect(logSpy).toHaveBeenCalledWith('Affected projects:\n - proj1');
@@ -254,6 +297,7 @@ describe('cli', () => {
           json: false,
           restArgs: [],
           tsConfigFilePath: 'tsconfig.base.json',
+          target: [],
         });
 
         expect(logSpy).toHaveBeenCalledWith(

--- a/libs/nx/src/cli.spec.ts
+++ b/libs/nx/src/cli.spec.ts
@@ -71,6 +71,7 @@ describe('cli', () => {
         json: false,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.base.json',
+        target: [],
       });
     });
 
@@ -93,6 +94,7 @@ describe('cli', () => {
         json: false,
         restArgs: [],
         tsConfigFilePath: 'tsconfig.json',
+        target: [],
       });
     });
   });

--- a/libs/nx/src/cli.ts
+++ b/libs/nx/src/cli.ts
@@ -133,7 +133,6 @@ const affectedCommand: CommandModule<unknown, AffectedOptions> = {
       coerce: (array: string[]) => {
         return array.flatMap((v) => v.split(',')).map((v) => v.trim());
       },
-      alias: ['t', 'targets'],
     },
   },
   handler: async ({

--- a/libs/nx/src/cli.ts
+++ b/libs/nx/src/cli.ts
@@ -133,6 +133,7 @@ const affectedCommand: CommandModule<unknown, AffectedOptions> = {
     target: {
       desc: 'Comma separate list of targets to filter affected projects by',
       type: 'array',
+      default: [],
       coerce: (array: string[]) => {
         return array.flatMap((v) => v.split(',')).map((v) => v.trim());
       },

--- a/libs/nx/src/cli.ts
+++ b/libs/nx/src/cli.ts
@@ -28,8 +28,11 @@ export const affectedAction = async ({
   let projects = await getNxTrueAffectedProjects(cwd);
 
   if (target.length) {
-    projects = projects.filter((project) =>
-      project.targets.some((projectTarget) => target.includes(projectTarget))
+    projects = projects.filter(
+      (project) =>
+        !!project.targets?.some((projectTarget) =>
+          target.includes(projectTarget)
+        )
     );
   }
 

--- a/libs/nx/src/nx.ts
+++ b/libs/nx/src/nx.ts
@@ -124,6 +124,7 @@ export async function getNxTrueAffectedProjects(
       sourceRoot: project.sourceRoot,
       implicitDependencies: project.implicitDependencies ?? [],
       tsConfig,
+      targets: Object.keys(project.targets ?? {}),
     };
   });
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,7 @@
     "paths": {
       "@traf/core": ["libs/core/src/index.ts"],
       "@traf/nx": ["libs/nx/src/cli.ts"],
-      "@traf/turbo": ["libs/turbo/src/cli.ts"],
+      "@traf/turbo": ["libs/turbo/src/cli.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
When running the truly affected command you can now supply a `--target` option that will filter affected projects by what targets they have, for example when passing `--target build` only projects that have a `build` target will be returned.